### PR TITLE
ci: fix var mismatch in actions

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Yarn build
         # Set environment variables required to perform the build. These are only available to this step
         env:
-          VITE_API_HOST: ${{ vars.VITE_API_HOST }}
+          VITE_API_HOST: ${{ vars.API_HOST }}
           VITE_GRAASP_APP_KEY: ${{ secrets.APP_KEY }}
           VITE_SENTRY_ENV: development
           VITE_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Yarn build
         # Set environment variables required to perform the build. These are only available to this step
         env:
-          VITE_API_HOST: ${{ vars.VITE_API_HOST }}
+          VITE_API_HOST: ${{ vars.API_HOST }}
           VITE_GRAASP_APP_KEY: ${{ secrets.APP_KEY }}
           VITE_SENTRY_ENV: production
           VITE_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Yarn build
         # Set environment variables required to perform the build. These are only available to this step
         env:
-          VITE_API_HOST: ${{ vars.VITE_API_HOST }}
+          VITE_API_HOST: ${{ vars.API_HOST }}
           VITE_GRAASP_APP_KEY: ${{ secrets.APP_KEY }}
           VITE_SENTRY_ENV: staging
           VITE_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>graasp/renovate-config"]
+  "extends": ["github>graasp/renovate-config:app"]
 }


### PR DESCRIPTION
Workflows were referring to VITE_API_HOST variable. In this repo, this var is available as API_HOST.

also fix renovate config